### PR TITLE
Feature/4 xml schema update

### DIFF
--- a/viscoll-api/app/controllers/export_controller.rb
+++ b/viscoll-api/app/controllers/export_controller.rb
@@ -38,13 +38,13 @@ class ExportController < ApplicationController
         xml = Nokogiri::XML(exportData)
         schema = Nokogiri::XML::RelaxNG(File.open("public/viscoll-datamodel81120.rng"))
         errors = schema.validate(xml)
-        if errors.empty?
-          render json: {data: exportData, type: @format, Images: {exportedImages:@zipFilePath ? @zipFilePath : false}}, status: :ok and return
-        else
-          render json: {data: errors, type: @format}, status: :unprocessable_entity and return
-        end
-        # skip validation and sending exportData even when errors
-        # render json: {data: exportData, type: @format, Images: {exportedImages:@zipFilePath ? @zipFilePath : false}}, status: :ok and return
+        # if errors.empty?
+        #   render json: {data: exportData, type: @format, Images: {exportedImages:@zipFilePath ? @zipFilePath : false}}, status: :ok and return
+        # else
+        #   render json: {data: errors, type: @format}, status: :unprocessable_entity and return
+        # end
+        #skip validation and sending exportData even when errors
+        render json: {data: exportData, type: @format, Images: {exportedImages:@zipFilePath ? @zipFilePath : false}}, status: :ok and return
       when "json"
         @data = buildJSON(@project)    
         render :'exports/show', status: :ok and return

--- a/viscoll-api/app/controllers/export_controller.rb
+++ b/viscoll-api/app/controllers/export_controller.rb
@@ -36,15 +36,15 @@ class ExportController < ApplicationController
       when "xml"
         exportData = buildDotModel(@project)
         xml = Nokogiri::XML(exportData)
-        schema = Nokogiri::XML::RelaxNG(File.open("public/viscoll-datamodel2.rng"))
+        schema = Nokogiri::XML::RelaxNG(File.open("public/viscoll-datamodel81120.rng"))
         errors = schema.validate(xml)
-        # if errors.empty?
-        #   render json: {data: exportData, type: @format, Images: {exportedImages:@zipFilePath ? @zipFilePath : false}}, status: :ok and return
-        # else
-        #   render json: {data: errors, type: @format}, status: :unprocessable_entity and return
-        # end
-        # skipping validation and sending exportData even when errors
-        render json: {data: exportData, type: @format, Images: {exportedImages:@zipFilePath ? @zipFilePath : false}}, status: :ok and return
+        if errors.empty?
+          render json: {data: exportData, type: @format, Images: {exportedImages:@zipFilePath ? @zipFilePath : false}}, status: :ok and return
+        else
+          render json: {data: errors, type: @format}, status: :unprocessable_entity and return
+        end
+        # skip validation and sending exportData even when errors
+        # render json: {data: exportData, type: @format, Images: {exportedImages:@zipFilePath ? @zipFilePath : false}}, status: :ok and return
       when "json"
         @data = buildJSON(@project)    
         render :'exports/show', status: :ok and return

--- a/viscoll-api/app/controllers/export_controller.rb
+++ b/viscoll-api/app/controllers/export_controller.rb
@@ -38,13 +38,13 @@ class ExportController < ApplicationController
         xml = Nokogiri::XML(exportData)
         schema = Nokogiri::XML::RelaxNG(File.open("public/viscoll-datamodel81120.rng"))
         errors = schema.validate(xml)
-        # if errors.empty?
-        #   render json: {data: exportData, type: @format, Images: {exportedImages:@zipFilePath ? @zipFilePath : false}}, status: :ok and return
-        # else
-        #   render json: {data: errors, type: @format}, status: :unprocessable_entity and return
-        # end
+        if errors.empty?
+          render json: {data: exportData, type: @format, Images: {exportedImages:@zipFilePath ? @zipFilePath : false}}, status: :ok and return
+        else
+          render json: {data: errors, type: @format}, status: :unprocessable_entity and return
+        end
         #skip validation and sending exportData even when errors
-        render json: {data: exportData, type: @format, Images: {exportedImages:@zipFilePath ? @zipFilePath : false}}, status: :ok and return
+        # render json: {data: exportData, type: @format, Images: {exportedImages:@zipFilePath ? @zipFilePath : false}}, status: :ok and return
       when "json"
         @data = buildJSON(@project)    
         render :'exports/show', status: :ok and return

--- a/viscoll-api/app/helpers/controller_helper/export_helper.rb
+++ b/viscoll-api/app/helpers/controller_helper/export_helper.rb
@@ -55,6 +55,7 @@ module ControllerHelper
           "params": {
             "material": leaf.material,
             "type": leaf.type,
+            "folio_number": leaf.folio_number ? leaf.folio_number : "",
             "attached_above": leaf.attached_above,
             "attached_below": leaf.attached_below,
             "stub": leaf.stub,
@@ -94,7 +95,6 @@ module ControllerHelper
         parentOrder =  @leafIDs.index(recto.parentID) + 1
         @rectos[index + 1] = {
           "params": {
-            "folio_number": recto.folio_number ? recto.folio_number : "",
             "page_number": recto.page_number ? recto.page_number : "",
             "texture": recto.texture, 
             "image": recto.image,

--- a/viscoll-api/public/viscoll-datamodel81120.rng
+++ b/viscoll-api/public/viscoll-datamodel81120.rng
@@ -1,0 +1,405 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<grammar ns="http://schoenberginstitute.org/schema/collation" 
+    xmlns="http://relaxng.org/ns/structure/1.0" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <start>
+        <element name="viscoll">
+            <oneOrMore>
+                <documentation xmlns="http://relaxng.org/ns/compatibility/annotations/1.0">On viscoll document may contain multiple textblock elements</documentation>
+                <element name="textblock">
+                    <documentation xmlns="http://relaxng.org/ns/compatibility/annotations/1.0">Optional @url points to a record describing the textblock, e.g. a catalog
+                        record</documentation>
+                    <optional>
+                        <element name="url">
+                            <data type="anyURI"/>
+                        </element>
+                    </optional>
+                    <optional>
+                        <element name="title">
+                            <documentation xmlns="http://relaxng.org/ns/compatibility/annotations/1.0">Optional
+                                @title provides the title of the textblock as defined by the people
+                                or group doing the cataloging (viscoll does not define
+                                title)</documentation>
+                            <text/>
+                        </element>
+                    </optional>
+                    <element name="shelfmark">
+                        <text/>
+                    </element>
+                    <optional>
+                        <element name="date">
+                            <documentation xmlns="http://relaxng.org/ns/compatibility/annotations/1.0">@date is
+                                optional and is undefined. Could be linked to a controlled
+                                vocabulary in tools (e.g., a list of centuries)</documentation>
+                            <text/>
+                        </element>
+                    </optional>
+                    <optional>
+                        <element name="origPlace">
+                            <documentation xmlns="http://relaxng.org/ns/compatibility/annotations/1.0">origPlace is optional and is undefined. Could be linked to a
+                                controlled vocabulary in tools</documentation>
+                            <text/>
+                        </element>
+                    </optional>
+
+
+                    <element name="direction">
+                        <documentation xmlns="http://relaxng.org/ns/compatibility/annotations/1.0">direction is required and the default value is l-r</documentation>
+                        <attribute name="val">
+                            <choice>
+                                <value>l-r</value>
+                                <value>r-l</value>
+                            </choice>
+                        </attribute>
+                    </element>
+
+                    <optional>
+                        <element name="format">
+                            <documentation xmlns="http://relaxng.org/ns/compatibility/annotations/1.0">refers to the format, usually of a printed book. Possible values are 2mo, 4mo, 8mo, 12mo, 16mo, 32mo, 64mo</documentation>
+                            <attribute name="val">
+                                <choice>
+                                    <value>2mo</value>
+                                    <value>4mo</value>
+                                    <value>8mo</value>
+                                    <value>12mo</value>
+                                    <value>16mo</value>
+                                    <value>24mo</value>
+                                </choice>
+                            </attribute>
+                        </element>
+                    </optional>
+
+                    <optional>
+                        <element name="paper_flavor">
+                            <documentation xmlns="http://relaxng.org/ns/compatibility/annotations/1.0">refers to the category list in the "Table of Fifteenth-Century Paper Flavors" for the Needham Calculator (http://www.needhamcalculator.net/)</documentation>
+                            <attribute name="val">
+                                <choice>
+                                    <value>imperial</value>
+                                    <value>super-royal</value>
+                                    <value>royal</value>
+                                    <value>super-median</value>
+                                    <value>median</value>
+                                    <value>super-chancery</value>
+                                    <value>chancery</value>
+                                    <value>half-median</value>
+                                </choice>
+                            </attribute>
+                        </element>
+                    </optional>
+
+
+                    <documentation xmlns="http://relaxng.org/ns/compatibility/annotations/1.0">The
+                        textblock begins with a list of quires</documentation>
+                    <element name="quires">
+                        <oneOrMore>
+                            <ref name="quire"/>
+                        </oneOrMore>
+                    </element>
+
+                    <element name="leaves">
+                        <oneOrMore>
+                            <documentation xmlns="http://relaxng.org/ns/compatibility/annotations/1.0">One leaf element to describe each leaf in the
+                            textblock</documentation>
+                            <element name="leaf">
+                                <optional>
+                                    <attribute name="stub">
+                                        <documentation xmlns="http://relaxng.org/ns/compatibility/annotations/1.0">If a leaf is a stub, the value of @stub is "yes" -
+                                        otherwise @stub is not there</documentation>
+                                        <value>yes</value>
+                                    </attribute>
+                                </optional>
+                                <attribute>
+                                    <name ns="http://www.w3.org/XML/1998/namespace">id</name>
+                                    <data type="NCName"/>
+                                </attribute>
+                                <optional>
+                                    <element name="folioNumber">
+                                        <attribute name="val">
+                                            <choice>
+                                                <data type="NMTOKEN"/>
+                                                <data type="string"/>
+                                                <empty/>
+                                            </choice>
+                                        </attribute>
+                                        <ref name="certainty"/>
+                                        <text/>
+                                    </element>
+                                </optional>
+                                <element name="mode">
+                                    <optional>
+                                        <ref name="certainty"/>
+                                    </optional>
+                                    <optional>
+                                        <attribute name="val">
+                                            <choice>
+                                                <value>original</value>
+                                                <value>added</value>
+                                                <value>replaced</value>
+                                                <value>missing</value>
+                                            </choice>
+                                        </attribute>
+                                    </optional>
+                                </element>
+                                <oneOrMore>
+                                    <element name="q">
+                                        <ref name="position"/>
+                                        <optional>
+                                            <ref name="leafno"/>
+                                        </optional>
+                                        <optional>
+                                            <ref name="certainty"/>
+                                        </optional>
+                                        <optional>
+                                            <ref name="target"/>
+                                        </optional>
+                                        <optional>
+                                            <attribute name="type">
+                                                <data type="NCName"/>
+                                            </attribute>
+                                        </optional>
+                                        <optional>
+                                            <ref name="n"/>
+                                        </optional>
+                                        <optional>
+                                            <element name="conjoin">
+                                                <ref name="certainty"/>
+                                                <ref name="target"/>
+                                                <text/>
+                                            </element>
+                                        </optional>
+                                        <optional>
+                                            <element name="single">
+                                                <documentation xmlns="http://relaxng.org/ns/compatibility/annotations/1.0">single only has the value of "yes" and is only used if the
+                                        leaf is a singleton</documentation>
+                                                <attribute name="val">
+                                                    <choice>
+                                                        <value>yes</value>
+                                                    </choice>
+                                                </attribute>
+                                                <optional>
+                                                    <ref name="certainty"/>
+                                                </optional>
+                                            </element>
+                                        </optional>
+                                    </element>
+                                </oneOrMore>
+                                <optional>
+                                    <element name="firstLeaf">
+                                        <documentation xmlns="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates the leaf (recto of) which is the start of the first quire.</documentation>
+                                        <attribute name="val">
+                                            <choice>
+                                                <value>yes</value>
+                                            </choice>
+                                        </attribute>
+                                        <optional>
+                                            <ref name="certainty"/>
+                                        </optional>
+                                    </element>
+                                </optional>
+                                <zeroOrMore>
+                                    <element name="foldout">
+                                        <documentation xmlns="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates if the leaf includes a foldout. The <direction/>
+ node specifies direction (out, up, or down). May be repeated if the leaf has multiple foldouts. The order of multiple foldouts must be the order in which the leaf is unfolded.</documentation>
+                                        <element name="direction">
+                                            <choice>
+                                                <value>out</value>
+                                                <value>in</value>
+                                                <value>up</value>
+                                                <value>down</value>
+                                            </choice>
+                                            <optional>
+                                                <ref name="certainty"/>
+                                            </optional>
+                                        </element>
+                                        <optional>
+                                            <ref name="certainty"/>
+                                        </optional>
+                                    </element>
+                                </zeroOrMore>
+                                <zeroOrMore>
+                                    <element name="attachment-method">
+                                        <documentation xmlns="http://relaxng.org/ns/compatibility/annotations/1.0">defines the values allowed for identifying the methods by which one leaf is attached to another. For "sewn" if there is a @target identified, the two leaves are sewn together, if there is no @target identified it is sewn through the fold. Use "sewn" through the fold only when you see it (i.e., in the center of a quire). Stitching goes through the margin instead of through the fold. Stitching will have one @target identifying the exit point.</documentation>
+                                        <ref name="certainty"/>
+                                        <optional>
+                                            <ref name="target"/>
+                                        </optional>
+                                        <optional>
+                                            <attribute name="type">
+                                                <choice>
+                                                    <value>sewn</value>
+                                                    <value>pasted</value>
+                                                    <value>tipped</value>
+                                                    <value>drummed</value>
+                                                    <value>stitched</value>
+                                                    <value>other</value>
+                                                </choice>
+                                            </attribute>
+                                        </optional>
+                                    </element>
+                                </zeroOrMore>
+                            </element>
+                        </oneOrMore>
+
+                    </element>
+
+                    <zeroOrMore>
+                        <element name="note">
+                            <ref name="target"/>
+                            <attribute name="type">
+                                <choice>
+                                    <value>certainty</value>
+                                    <text/>
+                                </choice>
+                            </attribute>
+                            <attribute>
+                                <name ns="http://www.w3.org/XML/1998/namespace">id</name>
+                            </attribute>
+                            <text/>
+                        </element>
+                    </zeroOrMore>
+                </element>
+            </oneOrMore>
+            <documentation xmlns="http://relaxng.org/ns/compatibility/annotations/1.0">viscoll
+                element begins with an optional set of taxonomy definitions</documentation>
+            <zeroOrMore>
+                <element>
+                    <name>taxonomy</name>
+                    <documentation xmlns="http://relaxng.org/ns/compatibility/annotations/1.0">if
+                        the taxonomy is defined externally, e.g. the Getty Art &amp; Architecture
+                        Thesaurus, include a @ref pointing to it</documentation>
+                    <optional>
+                        <attribute name="ref">
+                            <data type="anyURI"/>
+                        </attribute>
+                    </optional>
+                    <attribute>
+                        <name ns="http://www.w3.org/XML/1998/namespace">id</name>
+                        <data type="NCName"/>
+                    </attribute>
+                    <element>
+                        <name>label</name>
+                        <text/>
+                    </element>
+                    <oneOrMore>
+                        <element>
+                            <documentation xmlns="http://relaxng.org/ns/compatibility/annotations/1.0">Any defined taxonomy must include at least one term. If the taxonomy is defined external to the viscoll document, the term must have a @ref pointing to the external definition</documentation>
+                            <name>term</name>
+                            <optional>
+                                <attribute name="ref">
+                                    <data type="anyURI"/>
+                                </attribute>
+                            </optional>
+                            <attribute>
+                                <name ns="http://www.w3.org/XML/1998/namespace">id</name>
+                                <data type="NCName"/>
+                            </attribute>
+                            <text/>
+                        </element>
+                    </oneOrMore>
+                </element>
+            </zeroOrMore>
+            <optional>
+                <element>
+                    <name>notes</name>
+                    <oneOrMore>
+                        <ref name="note"/>
+                    </oneOrMore>
+                </element>
+            </optional>
+            <optional>
+                <element>
+                    <name>mapping</name>
+                    <oneOrMore>
+                        <element>
+                            <name>map</name>
+                            <optional>
+                                <attribute name="side">
+                                    <data type="NCName"/>
+                                </attribute>
+                            </optional>
+                            <optional>
+                                <ref name="target"/>
+                            </optional>
+                            <element>
+                                <name>term</name>
+                                <ref name="target"/>
+                            </element>
+                        </element>
+                    </oneOrMore>
+                </element>
+            </optional>
+        </element>
+    </start>
+    <define name="n">
+        <attribute name="n">
+            <data type="NMTOKEN"/>
+        </attribute>
+    </define>
+    <define name="certainty">
+        <attribute name="certainty">
+            <documentation xmlns="http://relaxng.org/ns/compatibility/annotations/1.0">values for @certainty: 1 = very certain, 2 = fairly certain, 3 = not certain</documentation>
+            <choice>
+                <value>1</value>
+                <value>2</value>
+                <value>3</value>
+            </choice>
+        </attribute>
+    </define>
+    <define name="position">
+        <attribute name="position">
+            <data type="positiveInteger"/>
+        </attribute>
+    </define>
+    <define name="leafno">
+        <attribute name="leafno">
+            <data type="positiveInteger"/>
+        </attribute>
+    </define>
+    <define name="target">
+        <attribute name="target">
+            <list>
+                <oneOrMore>
+                    <data type="anyURI"/>
+                </oneOrMore>
+            </list>
+        </attribute>
+    </define>
+    <define name="quire">
+        <element name="quire">
+            <optional>
+                <ref name="certainty"/>
+            </optional>
+            <optional>
+                <ref name="n"/>
+            </optional>
+            <optional>
+                <documentation xmlns="http://relaxng.org/ns/compatibility/annotations/1.0">subquires must point to a parent quire</documentation>
+                <attribute name="parent">
+                    <data type="IDREF"/>
+                </attribute>
+            </optional>
+            <optional>
+                <attribute>
+                    <name ns="http://www.w3.org/XML/1998/namespace">id</name>
+                    <data type="ID"/>
+                </attribute>
+            </optional>
+            <data type="short"/>
+        </element>
+    </define>
+    <define name="note">
+            <element name="note">
+                <ref name="target"/>
+                <attribute name="type">
+                    <choice>
+                        <value>certainty</value>
+                        <text/>
+                    </choice>
+                </attribute>
+                <attribute>
+                    <name ns="http://www.w3.org/XML/1998/namespace">id</name>
+                </attribute>
+                <text/>
+            </element>
+        
+    </define>
+</grammar>


### PR DESCRIPTION
#4 
Added the most recent schema, re-enabled validation, and moved taxonomy creation to outside the <textblock> element in export_helper.rb, as this is what the schema wants. This version of export_helper.rb should take precedence over feature/3, since the taxonomy is in the incorrect location on that branch.